### PR TITLE
Feature/wiki56347

### DIFF
--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -361,9 +361,9 @@ export function flatMap(ast, fn) {
         for(var i=startCnt ; i<node.children.length ; i++){
             // #56408 ページが表示できない件の対応 Mod Start
             //if(node.children[i].value && (node.children[i].value.match(/.*\>\*{1,3}/) || []).length === 1){
-            if(node.children[i].value && (node.children[i].value.match(/.*\u>\*{1,3}/) || []).length === 1
-                || (node.children[i].value && (node.children[i].value.match(/.*\span>\*{1,3}/) || []).length === 1)){
-            // #56408 ページが表示できない件の対応 Mod End
+            const v = node.children[i].value;
+            if (v && (/.*\u>\*{1,3}/.test(v) || /.*\span>\*{1,3}/.test(v))) {
+                // #56408 ページが表示できない件の対応 Mod End
                 endCnt = i;
                 break;
             }

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -292,27 +292,20 @@ export function flatMap(ast, fn) {
         var remainingChildren = [];
         var remainingChildren2 = [];
         var frontStr = node.children[startCnt].value.replace(/\*{1,3}<.*/,'');       // アスタリスク前
-        var regex = new RegExp(frontStr + '\\*{1,3}');
-        var frontStrAfter = node.children[startCnt].value.replace(regex,'');       // アスタリスク後
         var endCnt = startCnt;
         var strChildren = [];
         // 終わりの場所を調べる
         for(var i=startCnt ; i<node.children.length ; i++){
-            if(node.children[i].value && (node.children[i].value.match(/.*(\>|>)\*{1,3}/) || []).length === 1){
+            if(node.children[i].value && (node.children[i].value.match(/.*\>\*{1,3}/) || []).length === 1){
                 endCnt = i;
                 break;
             }
         }
-        var tailStr = node.children[endCnt].value.replace(/.*(\>|>)\*{1,3}/,'');   // アスタリスク後
+        var tailStr = node.children[endCnt].value.replace(/.*\>\*{1,3}/,'');   // アスタリスク後
         if(endCnt >= 1 ){
             for(var tailCnt=1 ; tailCnt<endCnt ; tailCnt++){
                 strChildren.push(node.children[tailCnt]);
             }
-            //test
-        }else if(frontStrAfter !== '' ){
-            var regexTail = new RegExp('\\*{1,3}' + tailStr);
-            var frontStrAfter2 = frontStrAfter.replace(regexTail,'');
-            strChildren.push({type: 'text', value: frontStrAfter2});
         }else{
             var str = node.children[startCnt].value.replace(frontStr,'').replace(tailStr,'').replace(/\*/g,''); // アスタリスクの中
             strChildren.push({type: 'text', value: str});
@@ -382,7 +375,7 @@ export function flatMap(ast, fn) {
                 }
                 tmpText = '';
             // #54864 開始タグと終了タグのみだった場合の対応
-            }else if(itemData[j] !== '' && (itemData[j].startsWith('\>') || itemData[j].startsWith('>'))){
+            }else if(itemData[j] !== '' && itemData[j].startsWith('\>')){
                 tmpText = '<' + itemData[j];
                 // #56280 blockquoteと文字装飾の対応
                 if(tmpText.startsWith('<>')){
@@ -401,11 +394,6 @@ export function flatMap(ast, fn) {
         // 残りのノードを詰め込む
         if(tmpText !== '' ){
             tmpNode.push({type: 'text' ,value : tmpText});
-        }
-
-        // tmpNodeが空の場合は何もしない
-        if(tmpNode.length === 0){
-            return spritCnt;
         }
 
         if(!(tmpNode[0].value.startsWith('<'))){

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -42,7 +42,10 @@ export function flatMap(ast, fn) {
                 }
                 //#51297 Add Start 下線文字色対応
                 if (node.children[sCnt] && node.children[sCnt].type === 'text' ) {
-                    if(/\*</.test(node.children[sCnt].value)) {
+                    // #56408 表示できないページの対応 Mod Start
+                    //if(/\*</.test(node.children[sCnt].value)) {
+                    if(/\*<span/.test(node.children[sCnt].value) || /\*<u/.test(node.children[sCnt].value )) {
+                    // #56408 表示できないページの対応 Mod End
                         // 太文字かイタリックが存在した場合（下線or文字色と同時の場合のみ）
                         subTransFormStrong(node,sCnt);
                     }
@@ -340,12 +343,27 @@ export function flatMap(ast, fn) {
     function subTransFormStrong(node,startCnt){
         var remainingChildren = [];
         var remainingChildren2 = [];
-        var frontStr = node.children[startCnt].value.replace(/\*{1,3}<.*/,'');       // アスタリスク前
+        // #56408 ページが表示できない件の対応 Mod Start
+        //var frontStr = node.children[startCnt].value.replace(/\*{1,3}<.*/,'');       // アスタリスク前
+        // 開始位置を把握
+        var frontStr = '';
+        if(/\*<span/.test(node.children[startCnt].value)){
+            frontStr = node.children[startCnt].value.replace(/\*{1,3}<span.*/,'');
+        }else if(/\*<u/.test(node.children[startCnt].value )) {
+            frontStr = node.children[startCnt].value.replace(/\*{1,3}<u.*/,'');
+        }else{
+            return;
+        }
+        // #56408 ページが表示できない件の対応 Mod End
         var endCnt = startCnt;
         var strChildren = [];
         // 終わりの場所を調べる
         for(var i=startCnt ; i<node.children.length ; i++){
-            if(node.children[i].value && (node.children[i].value.match(/.*\>\*{1,3}/) || []).length === 1){
+            // #56408 ページが表示できない件の対応 Mod Start
+            //if(node.children[i].value && (node.children[i].value.match(/.*\>\*{1,3}/) || []).length === 1){
+            if(node.children[i].value && (node.children[i].value.match(/.*\u>\*{1,3}/) || []).length === 1
+                || (node.children[i].value && (node.children[i].value.match(/.*\span>\*{1,3}/) || []).length === 1)){
+            // #56408 ページが表示できない件の対応 Mod End
                 endCnt = i;
                 break;
             }

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -292,20 +292,27 @@ export function flatMap(ast, fn) {
         var remainingChildren = [];
         var remainingChildren2 = [];
         var frontStr = node.children[startCnt].value.replace(/\*{1,3}<.*/,'');       // アスタリスク前
+        var regex = new RegExp(frontStr + '\\*{1,3}');
+        var frontStrAfter = node.children[startCnt].value.replace(regex,'');       // アスタリスク後
         var endCnt = startCnt;
         var strChildren = [];
         // 終わりの場所を調べる
         for(var i=startCnt ; i<node.children.length ; i++){
-            if(node.children[i].value && (node.children[i].value.match(/.*\>\*{1,3}/) || []).length === 1){
+            if(node.children[i].value && (node.children[i].value.match(/.*(\>|>)\*{1,3}/) || []).length === 1){
                 endCnt = i;
                 break;
             }
         }
-        var tailStr = node.children[endCnt].value.replace(/.*\>\*{1,3}/,'');   // アスタリスク後
+        var tailStr = node.children[endCnt].value.replace(/.*(\>|>)\*{1,3}/,'');   // アスタリスク後
         if(endCnt >= 1 ){
             for(var tailCnt=1 ; tailCnt<endCnt ; tailCnt++){
                 strChildren.push(node.children[tailCnt]);
             }
+            //test
+        }else if(frontStrAfter !== '' ){
+            var regexTail = new RegExp('\\*{1,3}' + tailStr);
+            var frontStrAfter2 = frontStrAfter.replace(regexTail,'');
+            strChildren.push({type: 'text', value: frontStrAfter2});
         }else{
             var str = node.children[startCnt].value.replace(frontStr,'').replace(tailStr,'').replace(/\*/g,''); // アスタリスクの中
             strChildren.push({type: 'text', value: str});
@@ -375,8 +382,13 @@ export function flatMap(ast, fn) {
                 }
                 tmpText = '';
             // #54864 開始タグと終了タグのみだった場合の対応
-            }else if(itemData[j] !== '' && itemData[j].startsWith('\>')){
+            }else if(itemData[j] !== '' && (itemData[j].startsWith('\>') || itemData[j].startsWith('>'))){
                 tmpText = '<' + itemData[j];
+                // #56280 blockquoteと文字装飾の対応
+                if(tmpText.startsWith('<>')){
+                    tmpText = itemData[j];
+                }
+                // #56280 blockquoteと文字装飾の対応
                 tmpNode.push({type: 'text' ,value : tmpText});
                 tmpText = '';
             // #54864 開始タグと終了タグのみだった場合の対応
@@ -389,6 +401,11 @@ export function flatMap(ast, fn) {
         // 残りのノードを詰め込む
         if(tmpText !== '' ){
             tmpNode.push({type: 'text' ,value : tmpText});
+        }
+
+        // tmpNodeが空の場合は何もしない
+        if(tmpNode.length === 0){
+            return spritCnt;
         }
 
         if(!(tmpNode[0].value.startsWith('<'))){

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -119,35 +119,34 @@ export function flatMap(ast, fn) {
       let match;
 
       while ((match = osfImagePattern.exec(text)) !== null) {
-          if (match.index > lastIndex) {
-              matches.push({ type: 'text', value: text.substring(lastIndex, match.index) });
-          }
+        if (match.index > lastIndex) {
+            matches.push({ type: 'text', value: text.substring(lastIndex, match.index) });
+        }
 
-          // @[osf](GUID)からURLを作る
-          const guid = match[1];
-          const osfURL = window.contextVars && window.contextVars.osfURL ? window.contextVars.osfURL : '';
-          let imageUrl = osfURL + guid + '/?action=download&mode=render';
+        // @[osf](GUID)からURLを作る
+        const guid = match[1];
+        const osfURL = window.contextVars && window.contextVars.osfURL ? window.contextVars.osfURL : '';
+        let imageUrl = osfURL + guid + '/?action=download&mode=render';
 
-          const $osfHelper = (typeof window !== 'undefined' && window.$osf && typeof window.$osf.urlParams === 'function')
-            ? window.$osf
-            : null;
-          if ($osfHelper && $osfHelper.urlParams && $osfHelper.urlParams().view_only) {
-              imageUrl += '&view_only=' + $osfHelper.urlParams().view_only;
-          }
+        const $osfHelper = (typeof window !== 'undefined' && window.$osf && typeof window.$osf.urlParams === 'function') ? window.$osf : null;
 
-          matches.push({
-              type: 'image',
-              alt: guid,
-              url: imageUrl
-          });
+        if ($osfHelper && $osfHelper.urlParams && $osfHelper.urlParams().view_only) {
+            imageUrl += '&view_only=' + $osfHelper.urlParams().view_only;
+        }
 
-          lastIndex = osfImagePattern.lastIndex;
-      }
+        matches.push({
+            type: 'image',
+            alt: guid,
+            url: imageUrl
+        });
 
-      // Add remaining text after the last match
-      if (lastIndex < text.length) {
-          matches.push({ type: 'text', value: text.substring(lastIndex) });
-      }
+        lastIndex = osfImagePattern.lastIndex;
+    }
+
+    // Add remaining text after the last match
+    if (lastIndex < text.length) {
+        matches.push({ type: 'text', value: text.substring(lastIndex) });
+    }
 
       return matches.length > 0 ? matches : null;
   }

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -82,6 +82,14 @@ export function flatMap(ast, fn) {
                         out.push(...transformedChildren);
                         break;
                     //#49455 Add End リンク付き画像対応
+                    } else if (nthChild.type === 'text' && /@\[osf\]\(/.test(nthChild.value)) {
+                        // Handle @[osf](GUID) format
+                        const transformed = transformOsfImage(nthChild);
+                        if (transformed && transformed.length > 0) {
+                            out.push(...transformed);
+                        } else {
+                            addTransformedChildren(nthChild, uLineCnt, node, out);
+                        }
                     } else {
                         addTransformedChildren(nthChild, uLineCnt, node, out);
                     }
@@ -101,6 +109,49 @@ export function flatMap(ast, fn) {
             }
         }
     }
+
+  function transformOsfImage(textNode) {
+      // Match @[osf](GUID) pattern
+      const osfImagePattern = /@\[osf\]\(([a-zA-Z0-9]{5,})\)/g;
+      const text = textNode.value;
+      const matches = [];
+      let lastIndex = 0;
+      let match;
+
+      while ((match = osfImagePattern.exec(text)) !== null) {
+          // Add text before the match
+          if (match.index > lastIndex) {
+              matches.push({ type: 'text', value: text.substring(lastIndex, match.index) });
+          }
+
+          // Create image node for @[osf](GUID)
+          const guid = match[1];
+          const osfURL = window.contextVars && window.contextVars.osfURL ? window.contextVars.osfURL : '';
+          let imageUrl = osfURL + guid + '/?action=download&mode=render';
+
+          // Check for view_only parameter
+          // Try to get $osf from global scope or window
+          var $osfHelper = (typeof $osf !== 'undefined') ? $osf : (window.$osf || null);
+          if ($osfHelper && $osfHelper.urlParams && $osfHelper.urlParams().view_only) {
+              imageUrl += '&view_only=' + $osfHelper.urlParams().view_only;
+          }
+
+          matches.push({
+              type: 'image',
+              alt: guid,
+              url: imageUrl
+          });
+
+          lastIndex = osfImagePattern.lastIndex;
+      }
+
+      // Add remaining text after the last match
+      if (lastIndex < text.length) {
+          matches.push({ type: 'text', value: text.substring(lastIndex) });
+      }
+
+      return matches.length > 0 ? matches : null;
+  }
 
   function transformImageSection(remainingChildren) {
       const result = [];

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -111,7 +111,7 @@ export function flatMap(ast, fn) {
     }
 
   function transformOsfImage(textNode) {
-      // Match @[osf](GUID) pattern
+      // @[osf](GUID) のパターン
       const osfImagePattern = /@\[osf\]\(([a-zA-Z0-9]{5,})\)/g;
       const text = textNode.value;
       const matches = [];
@@ -119,19 +119,18 @@ export function flatMap(ast, fn) {
       let match;
 
       while ((match = osfImagePattern.exec(text)) !== null) {
-          // Add text before the match
           if (match.index > lastIndex) {
               matches.push({ type: 'text', value: text.substring(lastIndex, match.index) });
           }
 
-          // Create image node for @[osf](GUID)
+          // @[osf](GUID)からURLを作る
           const guid = match[1];
           const osfURL = window.contextVars && window.contextVars.osfURL ? window.contextVars.osfURL : '';
           let imageUrl = osfURL + guid + '/?action=download&mode=render';
 
-          // Check for view_only parameter
-          // Try to get $osf from global scope or window
-          var $osfHelper = (typeof $osf !== 'undefined') ? $osf : (window.$osf || null);
+          const $osfHelper = (typeof window !== 'undefined' && window.$osf && typeof window.$osf.urlParams === 'function')
+            ? window.$osf
+            : null;
           if ($osfHelper && $osfHelper.urlParams && $osfHelper.urlParams().view_only) {
               imageUrl += '&view_only=' + $osfHelper.urlParams().view_only;
           }


### PR DESCRIPTION
Add a description

@[osf](GUID) 形式の画像が表示されない不具合を修正しました。
画像URLの生成処理とレンダリング部分を見直し、正常に画像が表示されるよう対応しています。

Changes

@[osf](GUID) を検出する正規表現を追加
画像URL生成ロジックを修正（?action=download&mode=render 付与の調整）
$osf / window.$osf の参照まわりを補強
誤ってテキスト扱いされていたパターンを画像ノードとして処理するよう改善

How to test

Wikiページなどで @[osf](GUID) を含むテキストを保存
対象のGUID画像が正しくレンダリングされることを確認