### PR TITLE
Feature/wiki 56347 2

### DIFF
--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -24,6 +24,31 @@ export function flatMap(ast, fn) {
             }
             //#51315 Add End 訂正線とコードブロック対応
             for (var sCnt = 0 ; sCnt < node.children.length ; sCnt++) {
+               // @[osf](GUID)形式のリンクを画像ノードに変換（エンコードされていない形式）
+                if (node.children[sCnt] && node.children[sCnt].type === 'link' &&
+                    node.children[sCnt].url && /^[a-zA-Z0-9]{5,}$/.test(node.children[sCnt].url) &&
+                    node.children[sCnt].children && node.children[sCnt].children.length > 0 &&
+                    node.children[sCnt].children[0] && node.children[sCnt].children[0].type === 'text' &&
+                    node.children[sCnt].children[0].value === 'osf' &&
+                    sCnt > 0 && node.children[sCnt - 1] && node.children[sCnt - 1].type === 'text' &&
+                    node.children[sCnt - 1].value === '@') {
+                    // @[osf](GUID)形式を画像ノードに変換
+                    const guid = node.children[sCnt].url;
+                    const osfURL = window.contextVars && window.contextVars.osfURL ? window.contextVars.osfURL : '';
+                    let imageUrl = osfURL + guid + '/?action=download&mode=render';
+                    const $osfHelper = (typeof window !== 'undefined' && window.$osf && typeof window.$osf.urlParams === 'function') ? window.$osf : null;
+                    if ($osfHelper && $osfHelper.urlParams && $osfHelper.urlParams().view_only) {
+                        imageUrl += '&view_only=' + $osfHelper.urlParams().view_only;
+                    }
+                    // @テキストノードとリンクノードを画像ノードに置き換え
+                    node.children.splice(sCnt - 1, 2, {
+                        type: 'image',
+                        alt: guid,
+                        url: imageUrl
+                    });
+                    sCnt--; // インデックスを調整
+                    continue;
+                }
                 //#48569 Add Start 子アンカー対応
                 if (node.children[sCnt] && node.children[sCnt].type === 'link') {
 

--- a/addons/wiki/static/utils.js
+++ b/addons/wiki/static/utils.js
@@ -85,7 +85,8 @@ export function flatMap(ast, fn) {
                         out.push(...transformedChildren);
                         break;
                     //#49455 Add End リンク付き画像対応
-                    } else if (nthChild.type === 'text' && /@\[osf\]\(/.test(nthChild.value)) {
+                    } else if (nthChild.type === 'text' && /@(?:\\\[|\[)osf(?:\\\]|\])\(/.test(nthChild.value)) {
+                    //} else if (nthChild.type === 'text' && /@\[osf\]\(/.test(nthChild.value)) {
                         // Handle @[osf](GUID) format
                         const transformed = transformOsfImage(nthChild);
                         if (transformed && transformed.length > 0) {
@@ -114,8 +115,8 @@ export function flatMap(ast, fn) {
     }
 
   function transformOsfImage(textNode) {
-      // @[osf](GUID) のパターン
-      const osfImagePattern = /@\[osf\]\(([a-zA-Z0-9]{5,})\)/g;
+      // @[osf](GUID) のパターン（エスケープされた形式とエスケープされていない形式の両方に対応）
+      const osfImagePattern = /@(?:\\\[|\[)osf(?:\\\]|\])\(([a-zA-Z0-9]{5,})\)/g;
       const text = textNode.value;
       const matches = [];
       let lastIndex = 0;


### PR DESCRIPTION
Summary
@[osf](GUID) 形式で入力されたテキストを、自動的に画像としてレンダリングできるように処理を追加しました。

Changes
@[osf](GUID) パターンを検出し、OSF の画像URLへ変換する処理を追加
view_only パラメータが存在する場合は画像URLに付与
@ ノード + link ノードを image ノードへ置き換えるロジックを実装
GUID 形式（英数字5文字以上）の検証を追加

How to Test
Wiki 編集画面で
@[osf](xxxxx) の形式で GUID を入力
プレビューまたは保存後、該当部分が画像として表示されることを確認
view_only パラメータ付きの URL でも正常に表示されることを確認