### PR TITLE
Read-only user access issue fix

### DIFF
--- a/addons/wiki/static/wikiPageMilkdown.js
+++ b/addons/wiki/static/wikiPageMilkdown.js
@@ -236,6 +236,10 @@ function ViewWidget(visible, version, viewText, rendered, contentURL, allowMathj
         self.allowFullRender();
         var requestURL;
         if (typeof self.version() !== 'undefined') {
+            var mMenuBarElement;
+            var mEditorElement;
+            var mEditorFooterElement;
+            var wikiViewRenderElement;
             if (self.version() === 'preview') {
                 var toMarkdown = '';
                 if (mEdit !== undefined) {
@@ -248,20 +252,20 @@ function ViewWidget(visible, version, viewText, rendered, contentURL, allowMathj
                 self.displaySource(toMarkdown);
                 var editWysiwygElement = document.getElementById('editWysiwyg');
                 if (editWysiwygElement && editWysiwygElement.style.display === 'none'){
-                    var mMenuBarElement = document.getElementById('mMenuBar');
-                    var mEditorFooterElement = document.getElementById('mEditorFooter');
+                    mMenuBarElement = document.getElementById('mMenuBar');
+                    mEditorFooterElement = document.getElementById('mEditorFooter');
                     if (mMenuBarElement) mMenuBarElement.style.display = '';
                     if (mEditorFooterElement) mEditorFooterElement.style.display = '';
                 }
-                var mEditorElement = document.getElementById('mEditor');
+                mEditorElement = document.getElementById('mEditor');
                 if (mEditorElement) mEditorElement.style.display = '';
-                var wikiViewRenderElement = document.getElementById('wikiViewRender');
+                wikiViewRenderElement = document.getElementById('wikiViewRender');
                 if (wikiViewRenderElement) wikiViewRenderElement.style.display = 'none';
             } else {
-                var mMenuBarElement = document.getElementById('mMenuBar');
-                var mEditorElement = document.getElementById('mEditor');
-                var mEditorFooterElement = document.getElementById('mEditorFooter');
-                var wikiViewRenderElement = document.getElementById('wikiViewRender');
+                mMenuBarElement = document.getElementById('mMenuBar');
+                mEditorElement = document.getElementById('mEditor');
+                mEditorFooterElement = document.getElementById('mEditorFooter');
+                wikiViewRenderElement = document.getElementById('wikiViewRender');
                 if (mMenuBarElement) mMenuBarElement.style.display = 'none';
                 if (mEditorElement) {
                     mEditorElement.style.display = 'none';

--- a/addons/wiki/static/wikiPageMilkdown.js
+++ b/addons/wiki/static/wikiPageMilkdown.js
@@ -413,9 +413,9 @@ function ViewModel(options){
         var collaborativeStatusElement = document.getElementById('collaborativeStatus');
         if (collaborativeStatusElement) {
             if (self.viewVersion() === 'preview') {
-                collaborativeStatusElement.style.display = "";
+                collaborativeStatusElement.style.display = '';
             } else {
-                collaborativeStatusElement.style.display = "none";
+                collaborativeStatusElement.style.display = 'none';
             }
         }
     });


### PR DESCRIPTION
Summary

読み取り専用ユーザで Wiki を閲覧できない事象が発生していたため、
表示制御および編集系の切り替え処理を見直し、権限に応じて正しく表示されるよう修正しました。

Background

読み取り専用ユーザで Wiki を表示した際に、
編集用コンポーネント（Milkdown / Editor系）の状態不整合により画面が正しく表示されない問題が発生
管理者・編集権限ユーザでは問題が再現しない状態でした

Changes

編集権限の有無に応じて以下の表示制御を明確化

読み取り専用ユーザの場合：
編集系を非表示
既存の div.milkdown が残っている場合は削除
View専用レンダリングのみを表示

編集可能ユーザの場合：
編集UIを正しく表示
Milkdownエディタが未生成の場合のみ生成するよう制御
collaborativeStatus の表示切り替え処理を null-safe に修正

Verification

読み取り専用ユーザ
Wiki が正常に閲覧できること
編集UI（メニュー・エディタ・フッター）が表示されないこと

管理者／編集可能ユーザ
Wiki を編集モードに切り替えられること
Wiki エディタが正常に表示・動作すること