### PR TITLE
UI: Truncate long file names in import screen

### DIFF
--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -228,3 +228,18 @@ $(document).unbind('keydown').bind('keydown', function (event) {
         }
     }
 });
+
+$(document).on('shown.bs.modal', '#alertInfo', function() {
+    $('#alertInfo ul li').each(function() {
+        var $li = $(this);
+        if (!$li.attr('title')) {
+            $li.attr('title', $li.text().trim());
+        }
+    });
+    $('#alertInfo #perFileDifinitionForm ul li div[name="WikiImportOperationPerName"]').each(function() {
+        var $div = $(this);
+        if (!$div.attr('title')) {
+            $div.attr('title', $div.text().trim());
+        }
+    });
+});


### PR DESCRIPTION
## Purpose

インポート画面において、ファイル名が長い場合に表示が崩れる問題があったため、
一定文字数を超えるファイル名は `...` を付けて省略表示する対応を行いました。

ユーザが一覧を確認しやすくなることを目的としています。

---

## Changes

- インポートファイル名が一定文字数を超えた場合に省略表示（`...`）する処理を追加
- 元のファイル名は保持したまま、表示のみを調整
- 既存のインポート処理・データ構造への影響はなし

---

## Side Effects

- 表示上は省略されるが、実体のファイル名や処理内容には影響なし

---

## Ticket

- [#56434](https://redmine.devops.rcos.nii.ac.jp/issues/56434)