### PR TITLE
Wiki本文の意図しない複製を防ぐ

### DIFF
--- a/addons/wiki/static/wikiPageMilkdown.js
+++ b/addons/wiki/static/wikiPageMilkdown.js
@@ -159,6 +159,157 @@ import { extendedImageSchemaPlugin, extendedInsertImageCommand, extendedUpdateIm
 import { linkInputRuleCosutom } from './link.js';
 import { customHeadingIdGenerator } from './heading.js';
 
+const INDEXEDDB_SYNC_TIMEOUT_MS = 800;
+
+function normalizeWikiMarkdown(markdown) {
+    return String(markdown || '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\n+$/g, '');
+}
+
+function isCollabXmlFragmentEmpty(yDoc) {
+    return yDoc.getXmlFragment('prosemirror').length === 0;
+}
+
+function waitForIndexeddbSynced(provider, timeoutMs) {
+    if (!provider || provider.synced) {
+        return Promise.resolve();
+    }
+    return Promise.race([
+        provider.whenSynced.catch(function() {}),
+        new Promise(function(resolve) {
+            setTimeout(resolve, timeoutMs);
+        })
+    ]);
+}
+
+// Attach IndexedDB only after websocket sync.
+// If the live collaborative document already has content, drop stale local
+// ops first so they cannot merge as a duplicate insert.
+async function attachIndexeddbForSession(yDoc, hasRemoteContent) {
+    if (!wikiId) {
+        console.error('Invalid wikiId: it must not be null, undefined, or empty');
+        return null;
+    }
+    if (hasRemoteContent) {
+        try {
+            await yIndexeddb.clearDocument(wikiId);
+        } catch (error) {
+            console.error('Failed to clear the wiki editor cache', error);
+        }
+    }
+    const provider = new yIndexeddb.IndexeddbPersistence(wikiId, yDoc);
+    if (!hasRemoteContent) {
+        await waitForIndexeddbSynced(provider, INDEXEDDB_SYNC_TIMEOUT_MS);
+    }
+    return provider;
+}
+
+var editorTypingAssistArmed = false;
+
+function withEditView(callback) {
+    if (!mEdit || typeof mEdit.action !== 'function') {
+        return null;
+    }
+    var result = null;
+    mEdit.action(function(ctx) {
+        result = callback(ctx, ctx.get(mCore.editorViewCtx));
+    });
+    return result;
+}
+
+function focusEditorForTyping(view) {
+    if (!view) {
+        return;
+    }
+    try {
+        const { TextSelection } = require('prosemirror-state');
+        const selection = TextSelection.atStart(view.state.doc);
+        view.dispatch(view.state.tr.setSelection(selection));
+    } catch (_error) {
+        // Selection restore is best-effort.
+    }
+    view.focus();
+    if (view.dom && typeof view.dom.focus === 'function') {
+        view.dom.focus();
+    }
+}
+
+function isEditorTypingTarget(event) {
+    if (readonly) {
+        return false;
+    }
+    const mEditorEl = document.getElementById('mEditor');
+    if (!mEditorEl || mEditorEl.style.display === 'none') {
+        return false;
+    }
+    const target = event.target;
+    if (!target) {
+        return true;
+    }
+    const tag = target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        return false;
+    }
+    if (typeof target.closest === 'function' && target.closest('.modal')) {
+        return false;
+    }
+    return true;
+}
+
+function onEditorTypingAssistKeyDown(event) {
+    if (!isEditorTypingTarget(event)) {
+        return;
+    }
+    withEditView(function(ctx, view) {
+        if (!view || view.hasFocus()) {
+            return;
+        }
+        // Same idea as toolbar buttons: focus under a real user keypress.
+        focusEditorForTyping(view);
+        if (event.isComposing) {
+            return;
+        }
+        if (event.ctrlKey || event.metaKey || event.altKey) {
+            return;
+        }
+        if (event.key && event.key.length === 1) {
+            event.preventDefault();
+            view.dispatch(view.state.tr.insertText(event.key));
+        }
+    });
+}
+
+function onEditorTypingAssistCompositionStart(event) {
+    if (!isEditorTypingTarget(event)) {
+        return;
+    }
+    withEditView(function(ctx, view) {
+        if (!view || view.hasFocus()) {
+            return;
+        }
+        focusEditorForTyping(view);
+    });
+}
+
+function armEditorTypingAssist() {
+    if (editorTypingAssistArmed) {
+        return;
+    }
+    document.addEventListener('keydown', onEditorTypingAssistKeyDown, true);
+    document.addEventListener('compositionstart', onEditorTypingAssistCompositionStart, true);
+    editorTypingAssistArmed = true;
+}
+
+function disarmEditorTypingAssist() {
+    if (!editorTypingAssistArmed) {
+        return;
+    }
+    document.removeEventListener('keydown', onEditorTypingAssistKeyDown, true);
+    document.removeEventListener('compositionstart', onEditorTypingAssistCompositionStart, true);
+    editorTypingAssistArmed = false;
+}
+
 async function createMView(editor, markdown) {
     if (editor && editor.destroy) {
         editor.destroy();
@@ -229,11 +380,6 @@ async function createMEditor(editor, vm, template) {
         return ret;
     };
 
-    if (!indexeddbProvider && wikiId) {
-        indexeddbProvider = new yIndexeddb.IndexeddbPersistence(wikiId, doc);
-    } else if (!wikiId) {
-        console.error('Invalid wikiId: it must not be null, undefined, or empty');
-    }
     if (!wsProvider) {
         wsProvider = new yWebsocket.WebsocketProvider(wsUrl, docId, doc, { disableBc: true });
     }
@@ -321,6 +467,9 @@ async function createMEditor(editor, vm, template) {
             requestAwarenessRefresh(wsProvider);
             await waitForAwarenessSettlement();
             const preferServerTemplate = !hasOtherAwarenessConnections(wsProvider);
+
+            const hasRemoteContent = !isCollabXmlFragmentEmpty(doc);
+            indexeddbProvider = await attachIndexeddbForSession(doc, hasRemoteContent);
 
             collabService
             .applyTemplate(template, (remoteNode, templateNode) => {
@@ -1129,6 +1278,7 @@ function ViewModel(options){
     self.editMode = function() {
       if(self.canEdit) {
         readonly = false;
+        armEditorTypingAssist();
 
         refreshEditorEditable();
         document.getElementById('mMenuBar').style.display = '';
@@ -1176,6 +1326,7 @@ function ViewModel(options){
         }
 
         readonly = true;
+        disarmEditorTypingAssist();
         refreshEditorEditable();
         document.getElementById('mMenuBar').style.display = 'none';
         document.getElementById('mEditorFooter').style.display = 'none';
@@ -1215,6 +1366,7 @@ function ViewModel(options){
         }
 
         readonly = true;
+        disarmEditorTypingAssist();
 
         document.getElementById('mMenuBar').style.display = 'none';
         document.getElementById('mEditorFooter').style.display = 'none';


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked the right branch:
- For hotfixes, select "master" as the target branch
- For new features, select "develop" as the target branch
- For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch
-->

## Purpose

Fix unintended duplication of Wiki page content in the Milkdown collaborative editor.

Stale local IndexedDB operations could be merged with the live Yjs document after y-websocket sync—for example, when a tab is closed without saving, the collaborative server state later becomes empty, and the user re-enters Edit while stale IndexedDB data still exists. This caused the same content to appear multiple times in the editor.

This PR connects IndexedDB persistence only after WebSocket sync and clears stale local IndexedDB data when the remote collaborative document already has content, preventing duplicate merges.

## Changes

- Add **`attachIndexeddbForSession`**: attach IndexedDB only after y-websocket sync; clear stale local IndexedDB ops when remote content already exists.
- Add helpers: `isCollabXmlFragmentEmpty`, `waitForIndexeddbSynced`.
- Update **`connectCollab`**: determine whether the remote document has content before attaching IndexedDB, instead of connecting IndexedDB immediately on editor creation.
- Add **typing assist** (`armEditorTypingAssist` / `disarmEditorTypingAssist`): restore editor focus when the user starts typing after entering edit mode.

**Changed files:** `addons/wiki/static/wikiPageMilkdown.js` only.

## QA Notes

- Does this change require a data migration? If so, what data will we migrate?
  - **No.** Frontend-only change.
- What is the level of risk?
  - **Low to medium.** Scope is limited to the Wiki Milkdown editor UI.
- Any permissions code touched?
  - **No.**
- Is this an additive or subtractive change, other?
  - **Behavioral fix** (not a breaking API change).
- How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
  - **Through UI** — Wiki edit page (Milkdown editor).
- If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - **N/A** — no API changes.
- What features or workflows might this change impact?
  - Wiki edit mode entry / re-entry
  - Edit after closing a tab without saving
  - Re-entering Edit when stale IndexedDB data remains and the collaborative server state is empty
- How will this impact performance?
  - **Minimal.** IndexedDB may be cleared once on connect when remote content exists.

### Suggested QA scenarios

1. **Single browser — tab close without save**
   - Save a Wiki page with a single line of content.
   - Open Edit, do not save, close the browser tab (not the in-page Close button).
   - Reopen the Wiki and enter Edit again.
   - **Expected:** Content remains a single line; no duplicate lines.

2. **Save and reload**
   - Edit, save, reload the page, enter Edit again.
   - **Expected:** Saved content loads correctly with no duplication.

3. **Typing after entering Edit**
   - Enter Edit on an empty or existing page and start typing immediately.
   - **Expected:** Characters appear in the editor without needing an extra click to focus.

4. **Stale IndexedDB + empty y-websocket (main repro)**
   - Save a Wiki page with a single line of content.
   - Browser A: Open Edit, then close the tab with × (not the in-page Close button).
   - Restart y-websocket so the collaborative server state is empty.
   - Browser B: Open Edit on the same Wiki, then close the tab with ×.
   - Browser A: Open Edit again.
   - **Expected:** Content remains a single line; no duplicate lines.

## Documentation

- No documentation updates required.
- No API versioning changes.

## Side Effects

- Local IndexedDB cache for a Wiki page may be cleared when reconnecting to a session where the remote collaborative document already has content. This is intentional to prevent stale local ops from merging as duplicate inserts.
- Requires deploying the rebuilt `wiki-edit-page.js` bundle for changes to take effect in the main application.

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/61562